### PR TITLE
trap errors and send back a JSON-parseable message

### DIFF
--- a/bundles/common-openstack/post.sh
+++ b/bundles/common-openstack/post.sh
@@ -3,6 +3,13 @@
 . /usr/share/conjure-up/hooklib/common.sh
 . $SCRIPTPATH/../bundle-common.sh
 
+exposeError() {
+    local parent_lineno="$1"
+    exposeResult  "Error on or near line ${parent_lineno}, maybe in ${BASH_SOURCE}" 1 "false"
+    exit 0
+}
+trap 'exposeError ${LINENO} ${BASH_SOURCE}' ERR
+
 keystone_status=$(unitStatus keystone 0)
 if [ $keystone_status != "active" ]; then
     exposeResult "Waiting for Keystone..." 1 "false"


### PR DESCRIPTION
Should help avoid crashing bugs in status screen during post-processing.

Part of a two part fix to errors in json parsing in the status screen that brings the whole thing down. This should stop us from sending non-json on errors, and https://github.com/Ubuntu-Solutions-Engineering/conjure-up/pull/6 will retry when it can't parse the json.

Signed-off-by: Michael McCracken mike.mccracken@canonical.com
